### PR TITLE
codeview: Remove error marks when setting code programmatically

### DIFF
--- a/src/codeview.js
+++ b/src/codeview.js
@@ -85,6 +85,7 @@ var Codeview = GObject.registerClass({
             if (this._buffer)
                 this._buffer.text = value;
             this._cached_ast = null;
+            this.setCompileResults([]);
         } finally {
             if (this._changedHandler)
                 GObject.signal_handler_unblock(this._buffer, this._changedHandler);


### PR DESCRIPTION
Previously, when you reset the code view while it had a pending error,
the error mark was never removed, so it remained on line 1. This code
removes any pending error marks when resetting the text.