### PR TITLE
hackyballs: Use common widget for popup choices menu

### DIFF
--- a/data/hackyballs/objectEditor.ui
+++ b/data/hackyballs/objectEditor.ui
@@ -47,20 +47,6 @@
     <property name="step_increment">15</property>
     <property name="page_increment">10</property>
   </object>
-  <object class="GtkPopover" id="menuSkin">
-    <property name="can_focus">False</property>
-    <child>
-      <object class="GtkFlowBox" id="choicesSkin">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="homogeneous">True</property>
-        <property name="column_spacing">6</property>
-        <property name="row_spacing">6</property>
-        <property name="min_children_per_line">4</property>
-        <property name="max_children_per_line">4</property>
-      </object>
-    </child>
-  </object>
   <template class="HBObjectEditor" parent="GtkGrid">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -78,7 +64,6 @@
             <property name="can_focus">True</property>
             <property name="receives_default">True</property>
             <property name="halign">center</property>
-            <property name="popover">menuSkin</property>
             <child>
               <placeholder/>
             </child>
@@ -676,6 +661,36 @@
             <property name="top_attach">3</property>
             <property name="height">4</property>
           </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
         </child>
         <child>
           <placeholder/>

--- a/src/hackyballs/objectEditor.js
+++ b/src/hackyballs/objectEditor.js
@@ -2,6 +2,7 @@
 
 const {GObject, Gtk} = imports.gi;
 const {HBSkinImage, HBSkinMaxIndex} = imports.hackyballs.skinImage;
+const {PopupMenu} = imports.popupMenu;
 
 var HBObjectEditor = GObject.registerClass({
     GTypeName: 'HBObjectEditor',
@@ -16,26 +17,17 @@ var HBObjectEditor = GObject.registerClass({
         'adjustmentSocial2',
         'buttonPhysics',
         'buttonSkin',
-        'choicesSkin',
         'imageObject0',
         'imageObject1',
         'imageObject2',
-        'menuSkin',
     ],
 }, class HBObjectEditor extends Gtk.Grid {
     _init(props = {}) {
         super._init(props);
 
-        const indexes = Array(HBSkinMaxIndex + 1).fill();
-        indexes.forEach((value, index) => {
-            const widget = new HBSkinImage({index: index, visible: true});
-            this._choicesSkin.add(widget);
-        });
-
-        this._imageSkin = new HBSkinImage({visible: true});
-        this._buttonSkin.add(this._imageSkin);
-        this._choicesSkin.connect('child-activated',
-            this._onChoicesActivated.bind(this));
+        const indices = Array.from({length: HBSkinMaxIndex + 1}, (v, i) => i);
+        this._menuSkin = new PopupMenu(this._buttonSkin, indices, HBSkinImage,
+            'index', {});
 
         this._imageSkin0 = new HBSkinImage({visible: true, pixels: 32});
         this._imageObject0.add(this._imageSkin0);
@@ -55,15 +47,9 @@ var HBObjectEditor = GObject.registerClass({
         model.bind_property(map['social0'], this._adjustmentSocial0, 'value', flags);
         model.bind_property(map['social1'], this._adjustmentSocial1, 'value', flags);
         model.bind_property(map['social2'], this._adjustmentSocial2, 'value', flags);
-        model.bind_property(map['skin'], this._imageSkin, 'index', flags);
+        model.bind_property(map['skin'], this._menuSkin, 'index', flags);
         model.bind_property(map['skin0'], this._imageSkin0, 'index', flags);
         model.bind_property(map['skin1'], this._imageSkin1, 'index', flags);
         model.bind_property(map['skin2'], this._imageSkin2, 'index', flags);
-    }
-
-    _onChoicesActivated(widget, child) {
-        const choice = child.get_child();
-        this._imageSkin.index = choice.index;
-        this._menuSkin.popdown();
     }
 });

--- a/src/hackyballs/skinImage.js
+++ b/src/hackyballs/skinImage.js
@@ -12,7 +12,7 @@ var HBSkinImage = GObject.registerClass({
             0, HBSkinMaxIndex, 0),
         pixels: GObject.ParamSpec.uint(
             'pixels', 'pixels', 'pixels',
-            GObject.ParamFlags.READWRITE,
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
             0, 64, 64),
     },
 }, class HBSkinImage extends Gtk.Image {


### PR DESCRIPTION
This uses the common popup menu widget that we also use in the framework
toolbox, for consistency. The common widget visually selects the chosen
option, which would otherwise need to be solved separately in the
hackyballs toolbox code.

https://phabricator.endlessm.com/T23984