### PR TITLE
codeview: Handle focus in-out-in in quick succession

### DIFF
--- a/src/codeview.js
+++ b/src/codeview.js
@@ -271,6 +271,15 @@ var Codeview = GObject.registerClass({
     }
 
     _onFocusIn() {
+        if (this._ambientMusicID === 'pending')
+            return Gdk.EVENT_PROPAGATE;
+        if (this._ambientMusicID === 'cancel') {
+            // Focused in and out and back in quickly, before the first UUID was
+            // returned. In this case, un-cancel the original sound but don't
+            // request another one.
+            this._ambientMusicID = 'pending';
+            return Gdk.EVENT_PROPAGATE;
+        }
         this._ambientMusicID = 'pending';
         SoundServer.getDefault().playAsync('codeview/ambient/hacking')
         .then(uuid => {


### PR DESCRIPTION
It can happen that you focus in, then out, then back in before the UUID
from the first sound returns. In that case, un-cancel the original sound
and just let it play, but don't request another one.

https://phabricator.endlessm.com/T24523