### PR TITLE
lockscreen: only play one active sound at the same time

### DIFF
--- a/src/Fizzics/controlpanel.js
+++ b/src/Fizzics/controlpanel.js
@@ -13,12 +13,12 @@ var FizzicsControlPanel = GObject.registerClass({
         'panelLevel2',
     ],
 }, class FizzicsControlPanel extends Gtk.Box {
-    _init(props = {}) {
+    _init(toolbox, props = {}) {
         super._init(props);
 
         this._level1 = new FizzicsLevel1({visible: true});
         this._level2 = new FizzicsLevel2({visible: true});
-        this._level2lock = new Lockscreen({visible: false});
+        this._level2lock = new Lockscreen({toolbox: toolbox, visible: false});
 
         this._level2lock.add(this._level2);
         this._panelLevel1.add(this._level1);

--- a/src/Fizzics/toolbox.js
+++ b/src/Fizzics/toolbox.js
@@ -14,7 +14,7 @@ var FizzicsToolbox = GObject.registerClass(class FizzicsToolbox extends Toolbox 
         props.title = _('Hack Modules');
         super._init(props);
         this._model = new FizzicsModelGlobal();
-        this._controlPanel = new FizzicsControlPanel({visible: true});
+        this._controlPanel = new FizzicsControlPanel(this, {visible: true});
         this._controlPanel.bindModel(this._model);
         this.add(this._controlPanel);
         this.show_all();

--- a/src/OperatingSystemApp/toolbox.js
+++ b/src/OperatingSystemApp/toolbox.js
@@ -8,6 +8,9 @@ var OSToolbox = GObject.registerClass(class OSToolbox extends Toolbox {
     _init(props = {}) {
         super._init(props);
         this._controlPanel = new OSControlPanel({visible: true});
+        this._controlPanel.wobblyLock.toolbox = this;
+        this._controlPanel.codeLock.toolbox = this;
+
         this.add(this._controlPanel);
         this.show_all();
 

--- a/src/app.js
+++ b/src/app.js
@@ -83,14 +83,17 @@ var HackToolboxApplication = GObject.registerClass(class extends Gtk.Application
 
         if (!this._windows[appId][windowId]) {
             const ToolboxClass = _toolboxClassForAppId(appId);
-            const toolbox = new ToolboxClass({visible: true});
-            const win = new ToolboxWindow({
+            const toolbox = new ToolboxClass({
+                target_app_id: appId,
+                visible: true,
+            });
+            const winProps = {
                 application: this,
                 decorated: _toolboxIsDecorated(appId),
                 target_app_id: appId,
                 target_window_id: windowId,
-            });
-            win.add(toolbox);
+            };
+            const win = new ToolboxWindow(toolbox, winProps);
             toolbox.bindWindow(win);
 
             const settings = Gtk.Settings.get_default();

--- a/src/framework/controlPanel.js
+++ b/src/framework/controlPanel.js
@@ -8,7 +8,7 @@ const {FrameworkLevel3} = imports.framework.level3;
 const {Lockscreen} = imports.lockscreen;
 
 var RaControlPanel = GObject.registerClass(class RaControlPanel extends Gtk.Grid {
-    _init(defaults, props = {}) {
+    _init(toolbox, defaults, props = {}) {
         Object.assign(props, {
             borderWidth: 24,
             rowSpacing: 24,
@@ -19,12 +19,16 @@ var RaControlPanel = GObject.registerClass(class RaControlPanel extends Gtk.Grid
         this._level1 = new FrameworkLevel1(defaults, {visible: true});
         this.attach(this._level1, 0, 0, 1, 1);
 
-        this._level2lock = new Lockscreen({visible: true, hexpand: true});
+        this._level2lock = new Lockscreen({
+            toolbox: toolbox,
+            visible: true,
+            hexpand: true,
+        });
         this._level2 = new FrameworkLevel2({visible: true, hexpand: true});
         this._level2lock.add(this._level2);
         this.attach(this._level2lock, 0, 1, 1, 1);
 
-        this._level3lock = new Lockscreen({visible: false});
+        this._level3lock = new Lockscreen({toolbox: toolbox, visible: false});
         this._level3 = new FrameworkLevel3(defaults, {visible: true});
         this._level3lock.add(this._level3);
         this.attach(this._level3lock, 1, 0, 1, 2);

--- a/src/framework/toolbox.js
+++ b/src/framework/toolbox.js
@@ -44,7 +44,8 @@ var FrameworkToolbox = GObject.registerClass(class FrameworkToolbox extends Tool
         });
         this._model.snapshot();  // ignore any initial syncing
 
-        this._controlPanel = new RaControlPanel(defaults, {visible: true});
+        this._controlPanel =
+            new RaControlPanel(win.toolbox, defaults, {visible: true});
         this._controlPanel.bindModel(this._model);
         this._controlPanel.bindWindow(win);
         this.add(this._controlPanel);

--- a/src/lockscreen.js
+++ b/src/lockscreen.js
@@ -4,12 +4,17 @@
 const {Gio, GLib, GObject, Gtk} = imports.gi;
 
 const {Playbin} = imports.playbin;
+const {Toolbox} = imports.toolbox;
 const SoundServer = imports.soundServer;
 
 var Lockscreen = GObject.registerClass({
     GTypeName: 'Lockscreen',
     CssName: 'lockscreen',
     Properties: {
+        toolbox: GObject.ParamSpec.object(
+            'toolbox', 'Toolbox', '',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            Toolbox),
         locked: GObject.ParamSpec.boolean('locked', 'Locked', '',
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
             true),
@@ -106,6 +111,14 @@ var Lockscreen = GObject.registerClass({
             `changed::${lock}`, this._updateLockStateWithLock.bind(this));
         this._lock = lock;
         this._updateLockStateWithLock();
+    }
+
+    get toolbox() {
+        return this._toolbox;
+    }
+
+    set toolbox(value) {
+        this._toolbox = value;
     }
 
     _updateBackground () {

--- a/src/soundServer.js
+++ b/src/soundServer.js
@@ -9,8 +9,17 @@ const SoundServerIface = `
       <arg type='s' name='sound_event' direction='in'/>
       <arg type='s' name='uuid' direction='out'/>
     </method>
+    <method name='PlaySoundAtBusName'>
+      <arg type='s' name='sound_event' direction='in'/>
+      <arg type='s' name='bus_name' direction='in'/>
+      <arg type='s' name='uuid' direction='out'/>
+    </method>
     <method name='StopSound'>
       <arg type='s' name='uuid' direction='in'/>
+    </method>
+    <method name='StopSoundAtBusName'>
+      <arg type='s' name='uuid' direction='in'/>
+      <arg type='s' name='bus_name' direction='in'/>
     </method>
     <signal name='Error'>
       <arg type='s' name='uuid'/>
@@ -56,6 +65,36 @@ class SoundServer {
     // async function
     playSync(id) {
         return this._proxy.PlaySoundSync(id);
+    }
+
+    // Fire and forget, no return value.
+    playAtBusName(id, appId) {
+        this._proxy.PlaySoundAtBusNameRemote(id, appId, (out, err) => {
+            if (err)
+                logError(err, `Error playing sound ${id} at bus name ${appId}`);
+        });
+    }
+
+    // Use sparingly, only if you need the return value, but also can't use an
+    // async function.
+    playAtBusNameAsync(id, appId) {
+        return new Promise((resolve, reject) => {
+            this._proxy.PlaySoundAtBusNameRemote(id, appId, (out, err) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+                const [uuid] = out;
+                resolve(uuid);
+            });
+        });
+    }
+
+    stopAtBusName(uuid, appId) {
+        this._proxy.StopSoundAtBusNameRemote(uuid, appId, (out, err) => {
+            if (err)
+                logError(err, `Error stopping sound ${uuid} at bus ${appId}`);
+        });
     }
 
     stop(uuid) {

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -13,6 +13,10 @@ const RESET_BUTTON_KEY = 'app.hack_toolbox.reset_button';
 var Toolbox = GObject.registerClass({
     CssName: 'toolbox',
     Properties: {
+        'target-app-id': GObject.ParamSpec.string('target-app-id',
+            'Target App ID', 'The App ID that this toolbox is "hacking"',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            ''),
         title: GObject.ParamSpec.string('title', 'Title', '',
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
             _('Hack')),

--- a/src/window.js
+++ b/src/window.js
@@ -15,10 +15,11 @@ var ToolboxWindow = GObject.registerClass({
             ''),
     },
 }, class ToolboxWindow extends Gtk.ApplicationWindow {
-    _init(params) {
+    _init(toolbox, params) {
         Object.assign(params, {expand: true});
         super._init(params);
 
+        this._toolbox = toolbox;
         // Need to create the hack toolbox after the window
         // is created, since we need its id
         const objectPath =
@@ -35,6 +36,7 @@ var ToolboxWindow = GObject.registerClass({
         this.set_visual(screen.get_rgba_visual());
 
         this._lockscreen = new Lockscreen({
+            toolbox: this._toolbox,
             expand: true,
             visible: true,
         });
@@ -57,6 +59,7 @@ var ToolboxWindow = GObject.registerClass({
             if (this._toolbox)
                 this._toolbox.shutdown();
         });
+        this._toolbox_frame.add(this._toolbox);
     }
 
     _onFlipBack() {
@@ -74,12 +77,6 @@ var ToolboxWindow = GObject.registerClass({
 
     get lockscreen() {
         return this._lockscreen;
-    }
-
-    // Override Gtk.Container.add()
-    add(widget) {
-        this._toolbox = widget;
-        this._toolbox_frame.add(widget);
     }
 
     get toolbox() {


### PR DESCRIPTION
A general rule:

* The active loop sound must be played IFF there is
  at least one active lockscreen.

To achieve this:

* Use the new SoundServer.playUnique API to ensure that,
  given many active lockscreens, only 1 will be played.
  This is done by tagging the "hack-toolbox/lockscreen/active"
  sound with "overlap-behavior" as "ignore" in the
  hack-sound-server metadata file.

* In order to avoid a complex inter-lockscreen coordination
  scheme, rely on the simple rule that, whenever a lockscreen
  is unlocked, it is an opportunity for another lockscreen to
  play its own active sound.

https://phabricator.endlessm.com/T24852