### PR TITLE
window: set toplevel window as modal

### DIFF
--- a/src/window.js
+++ b/src/window.js
@@ -16,7 +16,8 @@ var ToolboxWindow = GObject.registerClass({
     },
 }, class ToolboxWindow extends Gtk.ApplicationWindow {
     _init(params) {
-        Object.assign(params, {expand: true});
+        Object.assign(params, {expand: true,
+                               modal: true});
         super._init(params);
 
         // Need to create the hack toolbox after the window


### PR DESCRIPTION
This ensures that every dialog, such as GtkColorChooserDialogs or
others, also end up being set as modal, since GTK will read whether
the toplevel is modal to determine whether to make those modal too.

https://phabricator.endlessm.com/T24879