### PR TITLE
toolbox: Make slider page sizes equal to step sizes

### DIFF
--- a/data/Fizzics/objectEditor.ui
+++ b/data/Fizzics/objectEditor.ui
@@ -30,32 +30,32 @@
   <object class="GtkAdjustment" id="adjustmentSocial0">
     <property name="lower">-30</property>
     <property name="upper">30</property>
-    <property name="step_increment">5</property>
-    <property name="page_increment">10</property>
+    <property name="step_increment">2</property>
+    <property name="page_increment">2</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSocial1">
     <property name="lower">-30</property>
     <property name="upper">30</property>
-    <property name="step_increment">5</property>
-    <property name="page_increment">10</property>
+    <property name="step_increment">2</property>
+    <property name="page_increment">2</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSocial2">
     <property name="lower">-30</property>
     <property name="upper">30</property>
-    <property name="step_increment">5</property>
-    <property name="page_increment">10</property>
+    <property name="step_increment">2</property>
+    <property name="page_increment">2</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSocial3">
     <property name="lower">-30</property>
     <property name="upper">30</property>
-    <property name="step_increment">5</property>
-    <property name="page_increment">10</property>
+    <property name="step_increment">2</property>
+    <property name="page_increment">2</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSocial4">
     <property name="lower">-30</property>
     <property name="upper">30</property>
-    <property name="step_increment">5</property>
-    <property name="page_increment">10</property>
+    <property name="step_increment">2</property>
+    <property name="page_increment">2</property>
   </object>
   <template class="FizzicsObjectEditor" parent="GtkGrid">
     <property name="visible">True</property>

--- a/data/HackUnlock/controlpanel.ui
+++ b/data/HackUnlock/controlpanel.ui
@@ -5,19 +5,19 @@
   <object class="GtkAdjustment" id="adjustmentAmplitude">
     <property name="upper">1.4</property>
     <property name="step_increment">0.05</property>
-    <property name="page_increment">10</property>
+    <property name="page_increment">0.05</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentFrequency">
     <property name="upper">50</property>
     <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentPhase">
     <property name="lower">-3</property>
     <property name="upper">3</property>
     <property name="value">-3</property>
     <property name="step_increment">0.1</property>
-    <property name="page_increment">10</property>
+    <property name="page_increment">0.1</property>
   </object>
   <template class="HUControlPanel" parent="GtkGrid">
     <property name="visible">True</property>


### PR DESCRIPTION
It looks like the page size is used as the scroll wheel delta for all
GtkRange instances, except scroll bars. Since it is easy to accidentally
send a scroll event on the target hardware's touchpad, we want the
scroll wheel delta to be the step size, not the page size, on all the
GtkScale instances that we have in our toolboxes.

The social force sliders in Fizzics already had a rather large step size
of 5, so additionally we reduce it to 2 here.

https://phabricator.endlessm.com/T24601