### PR TITLE
framework: One more fix for human-readable color names

### DIFF
--- a/src/framework/utils.js
+++ b/src/framework/utils.js
@@ -121,7 +121,7 @@ function rgbaToString(rgba) {
         '#7fff00': 'chartreuse',
         '#d2691e': 'chocolate',
         '#ff7f50': 'coral',
-        '#6495ed': 'cornflower',
+        '#6495ed': 'cornflower blue',
         '#fff8dc': 'cornsilk',
         '#dc143c': 'crimson',
         '#00ffff': 'cyan',


### PR DESCRIPTION
Found one more non-roundtrippable name. (This was actually due to a
mistake in the Wikipedia page where I got the names from.)

https://phabricator.endlessm.com/T25086