### PR TITLE
lockscreen: Play unlock sound when unlocking

### DIFF
--- a/src/lockscreen.js
+++ b/src/lockscreen.js
@@ -225,6 +225,8 @@ var Lockscreen = GObject.registerClass({
             return;
         }
 
+        SoundServer.getDefault().play(`hack-toolbox/lockscreen/open/${this._lock}`);
+
         /* We are going to need to playback an animation */
         if (this._openURI)
             this._playbin.uri = this._openURI;


### PR DESCRIPTION
We automatically generate the name of the sound hook, from the lock ID.
(If we accidentally play a sound that doesn't exist, for example
hack-toolbox/lockscreen/open/default, we'll just get a warning in the
journal.)

https://phabricator.endlessm.com/T25051