### PR TITLE
framework: Align lockscreens vertically

### DIFF
--- a/src/framework/controlPanel.js
+++ b/src/framework/controlPanel.js
@@ -19,12 +19,19 @@ var RaControlPanel = GObject.registerClass(class RaControlPanel extends Gtk.Grid
         this._level1 = new FrameworkLevel1(defaults, {visible: true});
         this.attach(this._level1, 0, 0, 1, 1);
 
-        this._level2lock = new Lockscreen({visible: true, hexpand: true});
+        this._level2lock = new Lockscreen({
+            hexpand: true,
+            valign: Gtk.Align.START,
+            visible: true,
+        });
         this._level2 = new FrameworkLevel2({visible: true, hexpand: true});
         this._level2lock.add(this._level2);
         this.attach(this._level2lock, 0, 1, 1, 1);
 
-        this._level3lock = new Lockscreen({visible: false});
+        this._level3lock = new Lockscreen({
+            valign: Gtk.Align.START,
+            visible: false,
+        });
         this._level3 = new FrameworkLevel3(defaults, {visible: true});
         this._level3lock.add(this._level3);
         this.attach(this._level3lock, 1, 0, 1, 2);

--- a/src/framework/level3.js
+++ b/src/framework/level3.js
@@ -37,7 +37,12 @@ var FrameworkLevel3 = GObject.registerClass({
 
         this._defaults = defaults;
 
-        this._codeview = new Codeview({visible: true});
+        this._codeview = new Codeview({
+            // Temporary fix for keeping the codeview the same height as it was
+            // in the original design
+            minContentHeight: 535,
+            visible: true,
+        });
         this.add(this._codeview);
 
         this.get_style_context().add_class('codeview-frame');


### PR DESCRIPTION
On large resoluitions, the lockscreens were being vertically aligned
with GTK_ALIGN_FILL, making the widgets they covered taller than the
actual lockscreen assets. This changes the vertical alignment so that
the lockscreens properly cover the locked widgets.

Also sets a minimum height on the codeview, to ensure that it remains
the same height as it was in the previous toolbox design, until we can
refactor that design to fit the new toolbox better.

https://phabricator.endlessm.com/T25805