### PR TITLE
toolbox: Init action always create the toolbox

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -79,7 +79,7 @@ var HackToolboxApplication = GObject.registerClass(class extends Gtk.Application
                 this._windows[appId] = {};
 
             if (this._windows[appId][windowId])
-                return;
+                this._windows[appId][windowId].destroy();
 
             const ToolboxClass = _toolboxClassForAppId(appId);
             const toolbox = new ToolboxClass(appId, {visible: true});


### PR DESCRIPTION
Reuse the toolbox window between app launches give us odd behaviour
because the toolbox that receives the changes is not synced with the app
window. This patch fix the problem rebuilding the windows always on the
init action callback.

https://phabricator.endlessm.com/T25862