### PR TITLE
Fix double sounds

### DIFF
--- a/src/LightSpeed/toolbox.js
+++ b/src/LightSpeed/toolbox.js
@@ -16,38 +16,38 @@ var LSToolbox = GObject.registerClass(class LSToolbox extends Toolbox {
         const iconTheme = Gtk.IconTheme.get_default();
         iconTheme.add_resource_path('/com/endlessm/HackToolbox/LightSpeed/icons');
 
-        this._global = new LSGlobalModel();
+        this._model = new LSGlobalModel();
 
         this._combinedTopic = new LSCombinedTopic();
-        this._combinedTopic.bindGlobal(this._global);
+        this._combinedTopic.bindModel(this._model);
         this.addTopic('game', 'Game', 'rocket-symbolic', this._combinedTopic);
 
         this._spawnEnemyTopic = new LSUserFunction('spawnEnemy');
-        this._spawnEnemyTopic.bindGlobal(this._global);
+        this._spawnEnemyTopic.bindModel(this._model);
         this.addTopic('spawnEnemy', 'Spawn', 'spawn-symbolic',
             this._spawnEnemyTopic);
         this.hideTopic('spawnEnemy');
 
         this._updateAsteroidTopic = new LSUserFunction('updateAsteroid');
-        this._updateAsteroidTopic.bindGlobal(this._global);
+        this._updateAsteroidTopic.bindModel(this._model);
         this.addTopic('updateAsteroid', 'Asteroid', 'asteroid-symbolic',
             this._updateAsteroidTopic);
         this.hideTopic('updateAsteroid');
 
         this._updateSpinnerTopic = new LSUserFunction('updateSpinner');
-        this._updateSpinnerTopic.bindGlobal(this._global);
+        this._updateSpinnerTopic.bindModel(this._model);
         this.addTopic('updateSpinner', 'Spinner', 'spinner-symbolic',
             this._updateSpinnerTopic);
         this.hideTopic('updateSpinner');
 
         this._updateSquidTopic = new LSUserFunction('updateSquid');
-        this._updateSquidTopic.bindGlobal(this._global);
+        this._updateSquidTopic.bindModel(this._model);
         this.addTopic('updateSquid', 'Squid', 'squid-symbolic',
             this._updateSquidTopic);
         this.hideTopic('updateSquid');
 
         this._updateBeamTopic = new LSUserFunction('updateBeam');
-        this._updateBeamTopic.bindGlobal(this._global);
+        this._updateBeamTopic.bindModel(this._model);
         this.addTopic('updateBeam', 'Beam', 'beam-symbolic',
             this._updateBeamTopic);
         this.hideTopic('updateBeam');
@@ -55,7 +55,8 @@ var LSToolbox = GObject.registerClass(class LSToolbox extends Toolbox {
         this._updateLevelInfo();
         this.show_all();
 
-        this._global.connect('notify::currentLevel', this._updateLevelInfo.bind(this));
+        this._updateLevelHandler = this._model.connect('notify::currentLevel',
+            this._updateLevelInfo.bind(this));
         this.connect('reset', this._onReset.bind(this));
 
         this._showTopicsInitially()
@@ -68,8 +69,8 @@ var LSToolbox = GObject.registerClass(class LSToolbox extends Toolbox {
     }
 
     _updateLevelInfo() {
-        let text = `Level ${this._global.currentLevel}`;
-        if (this._global.currentLevel === 0)
+        let text = `Level ${this._model.currentLevel}`;
+        if (this._model.currentLevel === 0)
             text = 'Intro';
         this.setInfo(text);
     }
@@ -109,5 +110,22 @@ var LSToolbox = GObject.registerClass(class LSToolbox extends Toolbox {
             this.revealTopic(topic);
         else
             this.hideTopic(topic);
+    }
+
+    shutdown() {
+        super.shutdown();
+
+        if (this._model && this._updateLevelHandler) {
+            this._model.disconnect(this._updateLevelHandler);
+            this._model = null;
+            this._updateLevelHandler = 0;
+        }
+
+        this._combinedTopic.unbindModel();
+        this._spawnEnemyTopic.unbindModel();
+        this._updateAsteroidTopic.unbindModel();
+        this._updateSpinnerTopic.unbindModel();
+        this._updateSquidTopic.unbindModel();
+        this._updateBeamTopic.unbindModel();
     }
 });

--- a/src/LightSpeed/userFunction.js
+++ b/src/LightSpeed/userFunction.js
@@ -126,12 +126,20 @@ var LSUserFunction = GObject.registerClass({
         this.get_style_context().add_class('user-function');
     }
 
-    bindGlobal(model) {
-        this._global = model;
-        this._globalNotifyHandler = model.connect('notify', this._onGlobalNotify.bind(this));
+    bindModel(model) {
+        this._model = model;
+        this._modelNotifyHandler = model.connect('notify', this._onGlobalNotify.bind(this));
 
         this._currentLevel = model.currentLevel;
-        this._bindModel(this._global.getModel(this._currentLevel));
+        this._bindModel(this._model.getModel(this._currentLevel));
+    }
+
+    unbindModel() {
+        this._unbindLocalModel();
+        if (this._model && this._modelNotifyHandler) {
+            this._model.disconnect(this._modelNotifyHandler);
+            this._modelNotifyHandler = 0;
+        }
     }
 
     _onGlobalNotify() {
@@ -141,11 +149,15 @@ var LSUserFunction = GObject.registerClass({
         this._bindModel(this._global.getModel(this._currentLevel));
     }
 
-    _bindModel(model) {
-        if (this._model)
-            this._model = null;
+    _unbindLocalModel() {
+        this._localModel = null;
+    }
 
-        this._model = model;
+    _bindLocalModel(model) {
+        if (this._localModel)
+            this._localModel = null;
+
+        this._localModel = model;
 
         const {name, args, modelProp} = USER_FUNCTIONS[this._codeview.userFunction];
         this._codeview.text = `function ${name}(${args.join(', ')}) {
@@ -201,6 +213,6 @@ ${code}
         this._codeview.setCompileResults([]);
 
         const funcBody = this._codeview.getFunctionBody(name);
-        this._model[modelProp] = funcBody;
+        this._localModel[modelProp] = funcBody;
     }
 });


### PR DESCRIPTION
For fizzics and lightspeed, the buttons are linked to modify the code on change, this is done connecting the model property notify signal and this model is not unref when the widget is destroyed so if you close and open again fizzics, every click will play two sounds and we'll have a traceback in the log because the callback is trying to update a destroyed widget.

This PR fixes this problem disconnecting all handlers from the model on widget destroy.