### PR TITLE
Lightspeed: Make a distinction between global and per-level functions

### DIFF
--- a/src/LightSpeed/globalParams.js
+++ b/src/LightSpeed/globalParams.js
@@ -12,6 +12,14 @@ var LSGlobalModel = GObject.registerClass({
             _propFlags, 0, Number.MAX_SAFE_INTEGER, 2),
         currentLevel: GObject.ParamSpec.double('currentLevel', 'Current level', '',
             _propFlags, 0, Number.MAX_SAFE_INTEGER, 0),
+        updateAsteroidCode: GObject.ParamSpec.string('updateAsteroidCode',
+            'Update asteroid code', '', _propFlags, ''),
+        updateSpinnerCode: GObject.ParamSpec.string('updateSpinnerCode',
+            'Update spinner code', '', _propFlags, ''),
+        updateSquidCode: GObject.ParamSpec.string('updateSquidCode',
+            'Update squid code', '', _propFlags, ''),
+        updateBeamCode: GObject.ParamSpec.string('updateBeamCode',
+            'Update beam code', '', _propFlags, ''),
     },
 }, class LSGlobalModel extends ClippyWrapper {
     _init(level, props = {}) {

--- a/src/LightSpeed/model.js
+++ b/src/LightSpeed/model.js
@@ -19,14 +19,6 @@ var LSModel = GObject.registerClass({
             _propFlags, 0, Number.MAX_SAFE_INTEGER, 500),
         spawnEnemyCode: GObject.ParamSpec.string('spawnEnemyCode',
             'Spawn enemy code', '', _propFlags, ''),
-        updateAsteroidCode: GObject.ParamSpec.string('updateAsteroidCode',
-            'Update asteroid code', '', _propFlags, ''),
-        updateSpinnerCode: GObject.ParamSpec.string('updateSpinnerCode',
-            'Update spinner code', '', _propFlags, ''),
-        updateSquidCode: GObject.ParamSpec.string('updateSquidCode',
-            'Update squid code', '', _propFlags, ''),
-        updateBeamCode: GObject.ParamSpec.string('updateBeamCode',
-            'Update beam code', '', _propFlags, ''),
     },
 }, class LSModel extends ClippyWrapper {
     _init(level, props = {}) {


### PR DESCRIPTION
User functions can now be per-level (spawnEnemy) or global (the four
update functions.) We move the model properties for the latter from the
per-level model to the global model, and introduce code in
userFunction.js to connect up the right notify signal handlers for each
case.

https://phabricator.endlessm.com/T25722