### PR TITLE
Add appdata file

### DIFF
--- a/data/com.endlessm.HackToolbox.appdata.xml
+++ b/data/com.endlessm.HackToolbox.appdata.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>com.endlessm.HackToolbox.desktop</id>
+  <metadata_license>CC0</metadata_license>
+  <project_license>LGPL-2.1</project_license>
+  <categories>
+    <category>Game</category>
+  </categories>
+  <name>Toolbox</name>
+  <summary>The other side of flip-to-hack</summary>
+
+  <description><p></p></description>
+
+  <url type="homepage">https://hack-computer.com/</url>
+
+  <releases>
+    <release date="2019-03-25" version="0.0.0"/>
+  </releases>
+
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-info">intense</content_attribute>
+  </content_rating>
+
+  <update_contact>hack@endlessm.com</update_contact>
+</component>

--- a/data/com.endlessm.HackToolbox.desktop
+++ b/data/com.endlessm.HackToolbox.desktop
@@ -4,7 +4,6 @@ Name=Hack Toolbox
 Comment=Hack Toolbox
 Type=Application
 Exec=com.endlessm.HackToolbox
-Icon=hack-toolbox
 Categories=Development;
 DBusActivatable=true
 StartupNotify=true

--- a/data/meson.build
+++ b/data/meson.build
@@ -7,6 +7,9 @@ gnome.compile_resources('com.endlessm.HackToolbox.data',
 install_data('com.endlessm.HackToolbox.desktop',
     install_dir: join_paths(get_option('datadir'), 'applications'))
 
+install_data('com.endlessm.HackToolbox.appdata.xml',
+    install_dir: join_paths(get_option('datadir'), 'appdata'))
+
 install_data('framework/app-descriptions/Hackdex_chapter_one.yaml',
     install_dir: join_paths(pkgdatadir, 'app-descriptions'))
 


### PR DESCRIPTION
We must remove the Icon: line from the desktop file, as that icon does
not exist, and appstream-compose will complain about that.

I believe that sending metrics which include code typed in by the user
requires the "intense" rating for social-info in the OARS metadata.

https://phabricator.endlessm.com/T26020