### PR TITLE
Lightspeed: Add spawnPowerup and activatePowerup topics

### DIFF
--- a/src/LightSpeed/globalParams.js
+++ b/src/LightSpeed/globalParams.js
@@ -20,6 +20,8 @@ var LSGlobalModel = GObject.registerClass({
             'Update squid code', '', _propFlags, ''),
         updateBeamCode: GObject.ParamSpec.string('updateBeamCode',
             'Update beam code', '', _propFlags, ''),
+        activatePowerupCode: GObject.ParamSpec.string('activatePowerupCode',
+            'Activate powerup code', '', _propFlags, ''),
     },
 }, class LSGlobalModel extends ClippyWrapper {
     _init(level, props = {}) {

--- a/src/LightSpeed/model.js
+++ b/src/LightSpeed/model.js
@@ -19,6 +19,8 @@ var LSModel = GObject.registerClass({
             _propFlags, 0, Number.MAX_SAFE_INTEGER, 500),
         spawnEnemyCode: GObject.ParamSpec.string('spawnEnemyCode',
             'Spawn enemy code', '', _propFlags, ''),
+        spawnPowerupCode: GObject.ParamSpec.string('spawnPowerupCode',
+            'Spawn powerup code', '', _propFlags, ''),
     },
 }, class LSModel extends ClippyWrapper {
     _init(level, props = {}) {

--- a/src/LightSpeed/toolbox.js
+++ b/src/LightSpeed/toolbox.js
@@ -52,6 +52,18 @@ var LSToolbox = GObject.registerClass(class LSToolbox extends Toolbox {
             this._updateBeamTopic);
         this.hideTopic('updateBeam');
 
+        this._spawnPowerupTopic = new LSUserFunction('spawnPowerup');
+        this._spawnPowerupTopic.bindGlobal(this._global);
+        this.addTopic('spawnPowerup', 'NAME', 'go-home-symbolic',
+            this._spawnPowerupTopic);
+        this.hideTopic('spawnPowerup');
+
+        this._activatePowerupTopic = new LSUserFunction('activatePowerup');
+        this._activatePowerupTopic.bindGlobal(this._global);
+        this.addTopic('activatePowerup', 'NAME', 'weather-snow-symbolic',
+            this._activatePowerupTopic);
+        this.hideTopic('activatePowerup');
+
         this._updateLevelInfo();
         this.show_all();
 
@@ -86,7 +98,7 @@ var LSToolbox = GObject.registerClass(class LSToolbox extends Toolbox {
 
     async _showTopicsInitially() {
         const topics = ['spawnEnemy', 'updateAsteroid', 'updateSpinner',
-            'updateSquid', 'updateBeam'];
+            'updateSquid', 'updateBeam', 'spawnPowerup', 'activatePowerup'];
         const gameState = GameState.getDefault();
 
         await Promise.all(topics.map(async topic => {
@@ -127,5 +139,7 @@ var LSToolbox = GObject.registerClass(class LSToolbox extends Toolbox {
         this._updateSpinnerTopic.unbindGlobalModel();
         this._updateSquidTopic.unbindGlobalModel();
         this._updateBeamTopic.unbindGlobalModel();
+        this._spawnPowerupTopic.unbindGlobalModel();
+        this._activatePowerupTopic.unbindGlobalModel();
     }
 });

--- a/src/LightSpeed/userFunction.js
+++ b/src/LightSpeed/userFunction.js
@@ -38,6 +38,12 @@ const COMMON_SCOPE = {
         return min;
     },
 
+    pickOne(...choices) {
+        if (choices.length === 0)
+            throw new Error('You need at least one thing to pick from');
+        return choices[0];
+    },
+
     sin(theta) {
         return Math.sin(theta);
     },
@@ -111,6 +117,36 @@ const USER_FUNCTIONS = {
         perLevel: false,
         getScope() {
             return Object.assign({}, COMMON_UPDATE_SCOPE, COMMON_SCOPE);
+        },
+    },
+    spawnPowerup: {
+        name: 'spawnPowerup',
+        args: [],
+        modelProp: 'spawnPowerupCode',
+        perLevel: true,
+        getScope() {
+            return Object.assign({
+                tickCount: 0,
+                tickDelay: 0,
+            }, COMMON_SCOPE);
+        },
+    },
+    activatePowerup: {
+        name: 'activatePowerup',
+        args: [],
+        modelProp: 'activatePowerupCode',
+        perLevel: false,
+        getScope() {
+            return Object.assign({
+                ship: {
+                    position: {x: 0, y: 0},
+                    invulnerableTimer: 0,
+                    shrinkTimer: 0,
+                    attractTimer: 0,
+                },
+                powerUpType: 0,
+                blowUpEnemies() {},  // eslint-disable-line no-empty-function
+            }, COMMON_SCOPE);
         },
     },
 };


### PR DESCRIPTION
These are connected to the new exported global variables in Lightspeed.
They are defined per-level.

Names and icon assets for the topics are not added yet. These are using
placeholder names and assets.

https://phabricator.endlessm.com/T26025