### PR TITLE
Lightspeed: Merge the two spawn topics into one (backup plan)

### DIFF
--- a/src/LightSpeed/spawnTopic.js
+++ b/src/LightSpeed/spawnTopic.js
@@ -1,0 +1,34 @@
+/* exported LSSpawnTopic */
+
+const {GObject, Gtk} = imports.gi;
+
+const {LSUserFunction} = imports.LightSpeed.userFunction;
+
+var LSSpawnTopic = GObject.registerClass({
+    Properties: {
+        'needs-attention': GObject.ParamSpec.boolean('needs-attention', 'Needs attention',
+            'Display an indicator on the button that it needs attention',
+            GObject.ParamFlags.READWRITE, false),
+    },
+}, class LSSpawnTopic extends Gtk.Grid {
+    _init(props = {}) {
+        props.orientation = Gtk.Orientation.VERTICAL;
+        super._init(props);
+
+        this._spawnEnemy = new LSUserFunction('spawnEnemy');
+        this.add(this._spawnEnemy);
+
+        this._spawnPowerup = new LSUserFunction('spawnPowerup');
+        this.add(this._spawnPowerup);
+    }
+
+    bindGlobal(model) {
+        this._spawnEnemy.bindGlobal(model);
+        this._spawnPowerup.bindGlobal(model);
+    }
+
+    unbindGlobalModel() {
+        this._spawnEnemy.unbindGlobalModel();
+        this._spawnPowerup.unbindGlobalModel();
+    }
+});

--- a/src/com.endlessm.HackToolbox.src.gresource.xml
+++ b/src/com.endlessm.HackToolbox.src.gresource.xml
@@ -31,6 +31,7 @@
     <file>LightSpeed/controlpanel.js</file>
     <file>LightSpeed/globalParams.js</file>
     <file>LightSpeed/model.js</file>
+    <file>LightSpeed/spawnTopic.js</file>
     <file>LightSpeed/toolbox.js</file>
     <file>LightSpeed/userFunction.js</file>
     <file>OperatingSystemApp/cursorImage.js</file>

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -172,6 +172,11 @@ var Toolbox = GObject.registerClass({
         topic.get_style_context().add_class('reveal');  // animates once
     }
 
+    isTopicVisible(id) {
+        const [topicRow] = this._findTopic(id);
+        return topicRow.visible;
+    }
+
     showTopic(id) {
         const [topicRow] = this._findTopic(id);
 


### PR DESCRIPTION
We now have two topics in the Lightspeed toolbox that have something to
do with spawning, and we want to merge them into one because having two
different ones is confusing.

This is the easier, backup-plan, version of what we actually want to do:
have the two functions in the same code view. For this backup plan, we
put both code views in the same topic.

https://phabricator.endlessm.com/T26244