### PR TITLE
Lockscreen: Manage GSS dbus service unknown error

### DIFF
--- a/src/gameState.js
+++ b/src/gameState.js
@@ -68,6 +68,9 @@ var getDefault = (function() {
                     const dict = variant.deep_unpack();
                     return dict[property].deep_unpack();
                 } catch (e) {
+                    if (e.matches(Gio.DBusError, Gio.DBusError.SERVICE_UNKNOWN))
+                        throw e;
+
                     return defaultValue;
                 }
             };

--- a/src/lockscreen.js
+++ b/src/lockscreen.js
@@ -193,7 +193,7 @@ var Lockscreen = GObject.registerClass({
         this._activeSoundID = null;
     }
 
-    _updateLockStateWithLock() {
+    _updateLockStateWithLock(retries = null) {
         this._playbin.hasLock = !!this._lock;
 
         if (!this._lock)
@@ -201,8 +201,28 @@ var Lockscreen = GObject.registerClass({
 
         this._updateBackground();
 
-        if (!this._manager.isUnlocked(this._lock))
+        try {
+            if (!this._manager.isUnlocked(this._lock))
+                return;
+        } catch (e) {
+            const retry = retries === null ? 3 : retries;
+            const nextTryTimeout = 100;
+
+            if (retry > 0) {
+                logError(e, 'Error trying to load unlock state, ' +
+                    `trying again in ${nextTryTimeout} milisecond`);
+                GLib.timeout_add(GLib.PRIORITY_HIGH, nextTryTimeout,
+                    () => {
+                        this._updateLockStateWithLock(retry - 1);
+                        return GLib.SOURCE_REMOVE;
+                    });
+            } else {
+                logError(e, 'Error trying to load unlock state');
+            }
+
             return;
+        }
+
         this.locked = false;
     }
 


### PR DESCRIPTION
There's a race condition where we try to call a method for the
GameStateService just during the service is shuting down and this causes
some problems.

This patch manages this kind of errors in the getDictValueSync method
that is the one causing problems with the lock screen.

https://phabricator.endlessm.com/T25728