### PR TITLE
Lightspeed: Discard changes on reset

### DIFF
--- a/src/LightSpeed/spawnTopic.js
+++ b/src/LightSpeed/spawnTopic.js
@@ -31,4 +31,9 @@ var LSSpawnTopic = GObject.registerClass({
         this._spawnEnemy.unbindGlobalModel();
         this._spawnPowerup.unbindGlobalModel();
     }
+
+    discardChanges() {
+        this._spawnEnemy.discardChanges();
+        this._spawnPowerup.discardChanges();
+    }
 });

--- a/src/LightSpeed/toolbox.js
+++ b/src/LightSpeed/toolbox.js
@@ -87,7 +87,16 @@ var LSToolbox = GObject.registerClass(class LSToolbox extends Toolbox {
             new GLib.Variant('(sava{sv})', ['reset', [], {}]),
             null, Gio.DBusCallFlags.NONE, -1, null);
         this._combinedTopic.reset();
-        // The user functions are reset by the LightSpeed app already
+
+        // In the case where there's an error in a code view, it will not have
+        // been synced to the Lightspeed game state. Any discrepancies between
+        // the code view and the game state must be discarded.
+        this._spawnTopic.discardChanges();
+        this._updateAsteroidTopic.discardChanges();
+        this._updateSpinnerTopic.discardChanges();
+        this._updateSquidTopic.discardChanges();
+        this._updateBeamTopic.discardChanges();
+        this._activatePowerupTopic.discardChanges();
     }
 
     async _showTopicsInitially() {

--- a/src/LightSpeed/userFunction.js
+++ b/src/LightSpeed/userFunction.js
@@ -304,4 +304,9 @@ ${code}
         const funcBody = this._codeview.getFunctionBody(name);
         this._updateCode(funcBody);
     }
+
+    discardChanges() {
+        this._setCode();
+        this.set_property('needs-attention', false);
+    }
 });


### PR DESCRIPTION
If a code view contains an error, then it will not have been synced to
the Lightspeed game state. It's possible that if the "last good" state
was identical to the default code, then we don't get a notify signal
when the game resets its code to the default code. So, we need to
explicitly discard any discrepancies between the code view and the state
from Lightspeed.

https://phabricator.endlessm.com/T26290