### PR TITLE
Lightspeed: show topics when game state is unreachable

### DIFF
--- a/src/LightSpeed/toolbox.js
+++ b/src/LightSpeed/toolbox.js
@@ -106,17 +106,26 @@ var LSToolbox = GObject.registerClass(class LSToolbox extends Toolbox {
 
         await Promise.all(topics.map(async topic => {
             const key = `lightspeed.topic.${topic}`;
-            const revealed = await gameState.getDictValue(key, 'visible', false);
-            if (revealed)
+            try {
+                const revealed = await gameState.getDictValue(key, 'visible', false);
+                if (revealed)
+                    this.showTopic(topic);
+            } catch (e) {
+                // fail conservatively
                 this.showTopic(topic);
+            }
         }));
 
         // Backwards compatibility with old game state
         if (!this.isTopicVisible('spawn')) {
-            const revealed = await gameState.getDictValue(
-                'lightspeed.topic.spawnEnemy', 'visible', false);
-            if (revealed)
+            try {
+                const revealed = await gameState.getDictValue(
+                    'lightspeed.topic.spawnEnemy', 'visible', false);
+                if (revealed)
+                    this.showTopic('spawn');
+            } catch (e) {
                 this.showTopic('spawn');
+            }
         }
 
         Signals._connect.call(gameState, 'changed', this._onGameStateChanged.bind(this));

--- a/src/gameState.js
+++ b/src/gameState.js
@@ -59,6 +59,9 @@ var getDefault = (function() {
                     const dict = variant.deep_unpack();
                     return dict[property].deep_unpack();
                 } catch (e) {
+                    if (e.matches(Gio.DBusError, Gio.DBusError.SERVICE_UNKNOWN))
+                        throw e;
+
                     return defaultValue;
                 }
             };


### PR DESCRIPTION
Emergency fix. Topics default to shown, when the game state service is
unreachable. This may sometimes show them when they are not yet supposed
to be shown, but at least they will not be hidden when the player needs
them in order to progress.

https://phabricator.endlessm.com/T25728