### PR TITLE
Lightspeed: Fix needs-attention forwarding in Spawn topic

### DIFF
--- a/src/LightSpeed/spawnTopic.js
+++ b/src/LightSpeed/spawnTopic.js
@@ -16,10 +16,22 @@ var LSSpawnTopic = GObject.registerClass({
         super._init(props);
 
         this._spawnEnemy = new LSUserFunction('spawnEnemy');
+        this._spawnEnemy.connect('notify::needs-attention',
+            this._notifyNeedsAttention.bind(this));
         this.add(this._spawnEnemy);
 
         this._spawnPowerup = new LSUserFunction('spawnPowerup');
+        this._spawnPowerup.connect('notify::needs-attention',
+            this._notifyNeedsAttention.bind(this));
         this.add(this._spawnPowerup);
+    }
+
+    _notifyNeedsAttention() {
+        this.notify('needs-attention');
+    }
+
+    get needs_attention() {
+        return this._spawnEnemy.needs_attention || this._spawnPowerup.needs_attention;
     }
 
     bindGlobal(model) {


### PR DESCRIPTION
Previously, I forgot to make the spawn topic's needs-attention property
depend on the needs-attention properties of both of the code views that
it contains.

https://phabricator.endlessm.com/T26291