### PR TITLE
Sidetrack: Unbind level editor topic from global model

### DIFF
--- a/src/RileyMaze/toolbox.js
+++ b/src/RileyMaze/toolbox.js
@@ -77,7 +77,7 @@ var RMZToolbox = GObject.registerClass(class RMZToolbox extends Toolbox {
 
         this._instructTopic.unbindGlobalModel();
         this._unitTopic.unbindGlobalModel();
-        this._instructTopic.unbindGlobalModel();
+        this._levelTopic.unbindGlobalModel();
     }
 });
 


### PR DESCRIPTION
Typo fix. Without this, the "Reset All" button tries to reset every
level editor topic that was ever created by this instance of the
toolbox.

https://phabricator.endlessm.com/T26381