### PR TITLE
playbin: Gst playbin properties in C

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,7 @@ gio = dependency('gio-2.0')
 gio_unix = dependency('gio-unix-2.0')
 glib = dependency('glib-2.0')
 gobject = dependency('gobject-2.0')
+gtk = dependency('gtk+-3.0')
 
 pkgdatadir = join_paths(get_option('datadir'), meson.project_name())
 gjs = find_program('gjs', 'gjs-console')

--- a/src/lib/htb-playbin.c
+++ b/src/lib/htb-playbin.c
@@ -1,0 +1,51 @@
+#include "htb.h"
+
+/**
+ * hack_toolbox_playbin_get_widget:
+ * @obj: The parent object
+ *
+ * Get the widget property of a gstbin object. This is a workaround to get
+ * the playbin widget in javascript because the direct access in gjs is not
+ * working since org.gnome.Platform//2.28
+ *
+ * Returns: (transfer full): a #GtkWidget
+ */
+GtkWidget *
+hack_toolbox_playbin_get_widget(GObject *obj)
+{
+  GtkWidget *widget = NULL;
+  GObject * sink = NULL;
+  g_object_get (obj, "video_sink", &sink, NULL);
+  g_object_get (sink, "widget", &widget, NULL);
+  return widget;
+}
+
+/**
+ * hack_toolbox_playbin_set_uri:
+ * @obj: The gstbin
+ *
+ * Set the uri property of a gstbin object. This is a workaround to set
+ * the playbin uri in javascript because the direct access in gjs is not
+ * working since org.gnome.Platform//2.28
+ */
+void
+hack_toolbox_playbin_set_uri(GObject *obj,
+                             char    *uri)
+{
+  g_object_set (obj, "uri", uri, NULL);
+}
+
+/**
+ * hack_toolbox_playbin_set_video_filter:
+ * @obj: The gstbin
+ *
+ * Set the uri property of a gstbin object. This is a workaround to set
+ * the playbin uri in javascript because the direct access in gjs is not
+ * working since org.gnome.Platform//2.28
+ */
+void
+hack_toolbox_playbin_set_video_filter(GObject *obj,
+                                      GObject *filter)
+{
+  g_object_set (obj, "video-filter", filter, NULL);
+}

--- a/src/lib/htb.h
+++ b/src/lib/htb.h
@@ -2,6 +2,7 @@
 
 #include <glib.h>
 #include <gio/gio.h>
+#include <gtk/gtk.h>
 
 G_BEGIN_DECLS
 
@@ -12,5 +13,16 @@ hack_toolbox_open_fd_readonly(GFile *file,
 int
 hack_toolbox_open_bytes(GBytes *bytes,
                         GError **error);
+
+GtkWidget *
+hack_toolbox_playbin_get_widget(GObject *obj);
+
+void
+hack_toolbox_playbin_set_uri(GObject *obj,
+                             char    *uri);
+
+void
+hack_toolbox_playbin_set_video_filter(GObject *obj,
+                                      GObject *filter);
 
 G_END_DECLS

--- a/src/meson.build
+++ b/src/meson.build
@@ -28,6 +28,7 @@ sources = [
     gdbus_targets[0],
     gdbus_targets[1],
     'lib/htb-file.c',
+    'lib/htb-playbin.c',
 ]
 
 include = include_directories('.')
@@ -40,7 +41,7 @@ main_library = shared_library('@0@-@1@'.format(meson.project_name(), api_version
     sources, installed_headers, private_headers,
     c_args: ['-DG_LOG_DOMAIN="@0@"'.format(namespace_name),
              '-DCOMPILING_HACKTOOLBOX'],
-    dependencies: [gio, gio_unix, glib, gobject],
+    dependencies: [gio, gio_unix, glib, gobject, gtk],
     include_directories: include, install: true,
     soversion: api_version, version: libtool_version)
 
@@ -52,7 +53,7 @@ introspection_sources = [
 
 gnome.generate_gir(main_library, extra_args: ['--warn-all', '--warn-error'],
     identifier_prefix: 'HackToolbox', include_directories: include,
-    includes: ['Gio-2.0', 'GLib-2.0', 'GObject-2.0'],
+    includes: ['Gio-2.0', 'GLib-2.0', 'GObject-2.0', 'Gtk-3.0'],
     install: true, namespace: namespace_name, nsversion: api_version,
     sources: introspection_sources, symbol_prefix: 'hack_toolbox')
 

--- a/src/playbin.js
+++ b/src/playbin.js
@@ -1,6 +1,6 @@
 /* exported Playbin */
 
-const {Gdk, GLib, GObject, Gtk, Gst} = imports.gi;
+const {Gdk, GLib, GObject, Gtk, Gst, HackToolbox} = imports.gi;
 
 const Lock = GObject.registerClass({
     CssName: 'lock',
@@ -74,13 +74,14 @@ var Playbin = GObject.registerClass({
         Gst.init_check(null);
 
         this._playbin = Gst.parse_launch('playbin3 name=playbin video-sink=gtksink');
-        this._playbin.videoFilter = Gst.parse_bin_from_description(
+        const videoFilter = Gst.parse_bin_from_description(
             'videocrop name=videocrop ! alpha method=green',
             true
         );
-        this._videocrop = this._playbin.videoFilter.get_by_name('videocrop');
+        this._videocrop = videoFilter.get_by_name('videocrop');
+        HackToolbox.playbin_set_video_filter(this._playbin, videoFilter);
 
-        this._video_widget = this._playbin.videoSink.widget;
+        this._video_widget = HackToolbox.playbin_get_widget(this._playbin);
         this._video_widget.expand = true;
         this._video_widget.noShowAll = true;
         this._video_widget.ignoreAlpha = false;
@@ -201,7 +202,7 @@ var Playbin = GObject.registerClass({
 
         if (this._uri) {
             this._ensurePlaybin();
-            this._playbin.uri = this._uri;
+            HackToolbox.playbin_set_uri(this._playbin, this._uri);
             this._playbin.set_state(Gst.State.PAUSED);
         }
     }


### PR DESCRIPTION
There's a problem with flatpak platforms bigger than 2.28 and accessing
gst playbin properties. This patch is a workaround to get/set properties
of the lock screen playbin widget from javascript, just creating the
methods in C.

https://phabricator.endlessm.com/T29102