### PR TITLE
playbin: workaround GJS regression

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,7 @@ gio = dependency('gio-2.0')
 gio_unix = dependency('gio-unix-2.0')
 glib = dependency('glib-2.0')
 gobject = dependency('gobject-2.0')
+gtk = dependency('gtk+-3.0')
 
 pkgdatadir = join_paths(get_option('datadir'), meson.project_name())
 gjs = find_program('gjs', 'gjs-console')

--- a/src/lib/htb-property.c
+++ b/src/lib/htb-property.c
@@ -1,0 +1,20 @@
+#include "htb.h"
+
+/**
+ * hack_toolbox_property_get_object:
+ * @obj: The parent object
+ *
+ * Gets an object property from an object. This is a workaround to get
+ * the playbin widget in javascript because the direct access in gjs is not
+ * working since org.gnome.Platform//2.28
+ *
+ * Returns: (transfer full): a #GObject
+ */
+GObject *
+hack_toolbox_property_get_object(GObject *obj, gchar *property)
+{
+  GObject *retval = NULL;
+  g_object_get (obj, property, &retval, NULL);
+  return retval;
+}
+

--- a/src/lib/htb.h
+++ b/src/lib/htb.h
@@ -2,6 +2,7 @@
 
 #include <glib.h>
 #include <gio/gio.h>
+#include <glib-object.h>
 
 G_BEGIN_DECLS
 
@@ -12,5 +13,8 @@ hack_toolbox_open_fd_readonly(GFile *file,
 int
 hack_toolbox_open_bytes(GBytes *bytes,
                         GError **error);
+
+GObject *
+hack_toolbox_property_get_object(GObject *obj, gchar *property);
 
 G_END_DECLS

--- a/src/meson.build
+++ b/src/meson.build
@@ -28,6 +28,7 @@ sources = [
     gdbus_targets[0],
     gdbus_targets[1],
     'lib/htb-file.c',
+    'lib/htb-property.c',
 ]
 
 include = include_directories('.')
@@ -40,7 +41,7 @@ main_library = shared_library('@0@-@1@'.format(meson.project_name(), api_version
     sources, installed_headers, private_headers,
     c_args: ['-DG_LOG_DOMAIN="@0@"'.format(namespace_name),
              '-DCOMPILING_HACKTOOLBOX'],
-    dependencies: [gio, gio_unix, glib, gobject],
+    dependencies: [gio, gio_unix, glib, gobject, gtk],
     include_directories: include, install: true,
     soversion: api_version, version: libtool_version)
 
@@ -52,7 +53,7 @@ introspection_sources = [
 
 gnome.generate_gir(main_library, extra_args: ['--warn-all', '--warn-error'],
     identifier_prefix: 'HackToolbox', include_directories: include,
-    includes: ['Gio-2.0', 'GLib-2.0', 'GObject-2.0'],
+    includes: ['Gio-2.0', 'GLib-2.0', 'GObject-2.0', 'Gtk-3.0'],
     install: true, namespace: namespace_name, nsversion: api_version,
     sources: introspection_sources, symbol_prefix: 'hack_toolbox')
 


### PR DESCRIPTION
There is a regression that is preventing setting/getting properties
from GStreamer objects using JS accessors.

We workaround this by use gobject set_property() functions and
a new custom symbols for getting object properties

https://phabricator.endlessm.com/T29102