### PR TITLE
fizzics: When error searching, do not compare index with value

### DIFF
--- a/src/Fizzics/level2.js
+++ b/src/Fizzics/level2.js
@@ -95,6 +95,24 @@ var FizzicsLevel2 = GObject.registerClass({
         return this._model[modelProp];
     }
 
+    _getValueForScopeValue(scopeProp, scopeValue) {
+        if (scopeProp === 'background')
+            return BACKGROUNDS[scopeValue];
+        if (scopeProp === 'skin')
+            return SKINS[scopeValue];
+        if (scopeProp === 'vfxBad')
+            return VFXS[scopeValue];
+        if (scopeProp === 'sfxBad')
+            return SFXS[scopeValue];
+        if (scopeProp === 'vfxGood')
+            return VFXS[scopeValue];
+        if (scopeProp === 'sfxGood')
+            return SFXS[scopeValue];
+        if (scopeProp === 'frozen')
+            return !scopeValue;
+        return scopeValue;
+    }
+
     _getValueForModel(scope, scopeProp) {
         void this;
         if (scopeProp === 'frozen')
@@ -237,14 +255,16 @@ var FizzicsLevel2 = GObject.registerClass({
             const value = this._getValueForScope(prop, modelProp);
             const type = typeof value;
             const options = this._getOptionsForScopeValue(scope, prop);
-            const baseMessage = `Unknown value "${scope[prop]}" for ${prop}`;
-            if (typeof scope[prop] !== type) {
+            const scopeValue = this._getValueForScopeValue(prop, scope[prop]);
+
+            const baseMessage = `Unknown value "${scopeValue}" for ${prop}`;
+            if (typeof scopeValue !== type) {
                 errors.push(this._errorRecordAtAssignmentLocation(
                     prefix ? `${prefix}${prop}` : prop,
                     `${baseMessage}: value must be a ${type}`,
                     value
                 ));
-            } else if (options !== null && options.indexOf(scope[prop]) === -1) {
+            } else if (options !== null && options.indexOf(scopeValue) === -1) {
                 errors.push(this._errorRecordAtAssignmentLocation(
                     prefix ? `${prefix}${prop}` : prop,
                     `${baseMessage}: value must be one of ` +


### PR DESCRIPTION
In commit 5ffe087, we switched to use constants as values instead
of strings.

The codeview before used to display:
```
background = "space"
```

But because kids was not used to "", that was changed in 5ffe087 to
```
background = space
```

In the new change, that `space` variable stored the underlaying
value which is an index, in this case the index 1.

On error search, we were comparing the types of the string 'space'
with the index 1, and similarly for other cases. This is why, the
codeview displayed a several amount of errors marked in red.

This commit, modifies _searchForErrorWithProps to do a proper type
comparison. It not only disappears all the bunch of errors
appearing on the Fizzics codeview when `item.key.fizzics.2` and
`lock.fizzics.2` keys were granted, but also because there are no
more errors, no error sound is emitted anymore when launching
Fizzics.

https://phabricator.endlessm.com/T29464#805655