### PR TITLE
Use clubhouse recordMetric instead of eosmetics

### DIFF
--- a/com.hack_computer.HackToolbox.json.in
+++ b/com.hack_computer.HackToolbox.json.in
@@ -22,8 +22,7 @@
     "--filesystem=host",
     "--filesystem=/var/lib/flatpak/exports/share/applications:ro",
     "--filesystem=/var/lib/flatpak/exports/share/icons:ro",
-    "--env=GSETTINGS_SCHEMA_DIR=/run/host/usr/share/glib-2.0/schemas/",
-    "--system-talk-name=com.endlessm.Metrics"
+    "--env=GSETTINGS_SCHEMA_DIR=/run/host/usr/share/glib-2.0/schemas/"
   ],
   "modules": [
     {

--- a/src/clubhouse.js
+++ b/src/clubhouse.js
@@ -35,6 +35,11 @@ const ClubhouseIface = `
       <arg type="s" direction="in" name="path"/>
       <arg type="v" direction="out" name="metadata"/>
     </method>
+    <method name="recordMetric">
+      <arg type="s" direction="in" name="key"/>
+      <arg type="v" direction="in" name="payload"/>
+      <arg type="a{sv}" direction="in" name="custom"/>
+    </method>
     <property name="Visible" type="b" access="read"/>
     <property name="RunningQuest" type="s" access="read"/>
     <property name="SuggestingOpen" type="b" access="read"/>

--- a/src/main.js
+++ b/src/main.js
@@ -30,7 +30,6 @@
 pkg.initGettext();
 pkg.initFormat();
 pkg.require({
-    EosMetrics: '0',
     Gdk: '3.0',
     GdkPixbuf: '2.0',
     Gtk: '3.0',


### PR DESCRIPTION
This PR requires the API in the clubhouse: https://github.com/endlessm/clubhouse/pull/1198

We are replacing the metrics system on the clubhouse to use a generic
matomo server instead of the eosmetrics. This patch removes the
dependency from the toolbox and uses the new clubhouse API to register
codeview error metrics.

https://phabricator.endlessm.com/T30942