### PR TITLE
utils: override AppInfo.get_icon for flatpak apps

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -72,6 +72,7 @@ function appInfoForAppId(id) {
 
     // Check system data dirs, and also flatpak export dirs and host's data dir
     const dirs = GLib.get_system_data_dirs().concat([
+        `${GLib.get_home_dir()}/.local/share/flatpak/exports/share`,
         '/var/lib/flatpak/exports/share',
         '/var/endless-extra/flatpak/exports/share',
         '/run/host/usr/share',
@@ -102,6 +103,16 @@ function appInfoForAppId(id) {
         // desktop ID and there is no way to set it after construction.
         appInfo.get_id = function() {
             return `${id}.desktop`;
+        };
+        // Need to override the get_icon function here - creating the desktop
+        // file with Gio.DesktopAppInfo.new_from_keyfile does not set the
+        // underlying desktop icon and there is no way to set it after
+        // construction.
+        appInfo.get_icon = function() {
+            const iconsDir = 'icons/hicolor/128x128/apps';
+            const iconName = desktopFile.get_string('Desktop Entry', 'Icon') || id;
+            const iconPath = GLib.build_filenamev([datadir, iconsDir, `${iconName}.png`]);
+            return Gio.FileIcon.new(Gio.File.new_for_path(iconPath));
         };
 
         return appInfo;


### PR DESCRIPTION
Inside the flatpak sandbox there's no visibility for flatpak apps so the
Gio.DesktopAppInfo.new(`${id}.desktop`) function will return null.

This patch adds access to the user flatpak installation and also
overrides the get_icon function to load the icon from the sandbox
filesystem path.

This requires some new sandbox permissions in the katamari manifest:
```
   "--filesystem=/var/lib/flatpak/exports/:ro",
   "--filesystem=/var/lib/flatpak/app/:ro",
   "--filesystem=~/.local/share/flatpak/exports/:ro",
   "--filesystem=~/.local/share/flatpak/app/:ro",
```
https://phabricator.endlessm.com/T31118