### PR TITLE
Extensions toolbox

### DIFF
--- a/data/Extensions/codeview.ui
+++ b/data/Extensions/codeview.ui
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.0 -->
+<interface>
+  <requires lib="gtk+" version="3.22"/>
+  <requires lib="hack-toolbox" version="0.0"/>
+  <template class="ExtensionsCodeview" parent="GtkGrid">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="border_width">20</property>
+    <property name="column_spacing">20</property>
+    <child>
+      <object class="Codeview" id="codeview">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">0</property>
+      </packing>
+    </child>
+  </template>
+</interface>

--- a/data/Extensions/snow/controlpanel.ui
+++ b/data/Extensions/snow/controlpanel.ui
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.0 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <requires lib="hack-toolbox" version="0.0"/>
+  <object class="GtkAdjustment" id="durationAdjustment">
+    <property name="lower">3</property>
+    <property name="upper">20</property>
+    <property name="value">12</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">5</property>
+  </object>
+  <object class="GtkAdjustment" id="maxAdjustment">
+    <property name="lower">2</property>
+    <property name="upper">40</property>
+    <property name="value">20</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">5</property>
+  </object>
+  <object class="GtkAdjustment" id="initialAdjustment">
+    <property name="lower">1</property>
+    <property name="upper">10</property>
+    <property name="value">5</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">2</property>
+  </object>
+  <object class="GtkAdjustment" id="meltAdjustment">
+    <property name="lower">0</property>
+    <property name="upper">5</property>
+    <property name="value">1</property>
+    <property name="step_increment">0.1</property>
+    <property name="page_increment">0.5</property>
+  </object>
+
+  <template class="SnowControlPanel" parent="GtkGrid">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="border_width">24</property>
+    <property name="row_spacing">24</property>
+    <property name="column_spacing">24</property>
+    <child>
+      <object class="Section">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="valign">start</property>
+        <property name="orientation">vertical</property>
+        <property name="heading">Snow Config</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="border_width">12</property>
+            <property name="spacing">12</property>
+            <child>
+              <object class="GtkMenuButton" id="flakesButton">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="halign">start</property>
+                <property name="valign">start</property>
+                <child>
+                  <placeholder/>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">12</property>
+                <child>
+                  <object class="SpinInput" id="duration">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="valign">start</property>
+                    <property name="orientation">vertical</property>
+                    <property name="label">Duration</property>
+                    <property name="adjustment">durationAdjustment</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="SpinInput" id="max">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="valign">start</property>
+                    <property name="orientation">vertical</property>
+                    <property name="label">Maximum</property>
+                    <property name="adjustment">maxAdjustment</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="SpinInput" id="initial">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="valign">start</property>
+                    <property name="orientation">vertical</property>
+                    <property name="label">Initial flakes</property>
+                    <property name="adjustment">initialAdjustment</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="SpinInput" id="melt">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="valign">start</property>
+                    <property name="orientation">vertical</property>
+                    <property name="label">Melt duration</property>
+                    <property name="digits">2</property>
+                    <property name="adjustment">meltAdjustment</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">1</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="Codeview" id="codeview">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">0</property>
+        <property name="height">2</property>
+      </packing>
+    </child>
+  </template>
+</interface>

--- a/data/com.hack_computer.HackToolbox.data.gresource.xml
+++ b/data/com.hack_computer.HackToolbox.data.gresource.xml
@@ -5,6 +5,8 @@
     <file compressed="true">codeview.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">section.ui</file>
     <file compressed="true">spininput.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">Extensions/codeview.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">Extensions/snow/controlpanel.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">framework/level1.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">framework/level2.ui</file>
     <file preprocess="xml-stripblanks">framework/animals.svg</file>

--- a/src/app.js
+++ b/src/app.js
@@ -52,6 +52,8 @@ function _toolboxClassForAppId(targetAppId) {
         return imports.RileyMaze.toolbox.RMZToolbox;
     case 'com.hack_computer.Sketchbook':
         return imports.sketchbook.toolbox.SketchToolbox;
+    case 'org.gnome.Extensions':
+        return imports.extensions.toolbox.ExtensionsToolbox;
     default:
         return imports.hacktoolbox.hacktoolbox.DefaultHackToolbox;
     }

--- a/src/codeview.js
+++ b/src/codeview.js
@@ -662,10 +662,10 @@ var Codeview = GObject.registerClass({
         }
     }
 
-    setCompileResultsFromException(exception, userInitiated = true) {
+    setCompileResultsFromException(exception, userInitiated = true, delta = -1) {
         this.setCompileResults([{
             start: {
-                line: exception.lineNumber - 1,  // remove initial "with(scope)" line
+                line: exception.lineNumber + delta,  // remove initial "with(scope)" line
                 column: exception.columnNumber - 1,  // seems to be 1-based
             },
             message: exception.message,

--- a/src/com.hack_computer.HackToolbox.src.gresource.xml
+++ b/src/com.hack_computer.HackToolbox.src.gresource.xml
@@ -19,6 +19,10 @@
     <file>framework/utils.js</file>
     <file>gameState.js</file>
     <file>hacktoolbox/hacktoolbox.js</file>
+    <file>extensions/toolbox.js</file>
+    <file>extensions/codeview.js</file>
+    <file>extensions/snow/controlpanel.js</file>
+    <file>extensions/snow/model.js</file>
     <file>Fizzics/controlpanel.js</file>
     <file>Fizzics/model.js</file>
     <file>Fizzics/toolbox.js</file>

--- a/src/extensions/codeview.js
+++ b/src/extensions/codeview.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2020 Endless OS Foundation LLC.
+ *
+ * This file is part of hack-toolbox-app
+ * (see https://github.com/endlessm/hack-toolbox-app).
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+/* exported ExtensionsCodeview */
+
+const {GObject, Gtk} = imports.gi;
+const {Codeview} = imports.codeview;
+
+GObject.type_ensure(Codeview.$gtype);
+
+var ExtensionsCodeview = GObject.registerClass({
+    GTypeName: 'ExtensionsCodeview',
+    Template: 'resource:///com/hack_computer/HackToolbox/Extensions/codeview.ui',
+    InternalChildren: [
+        'codeview',
+    ],
+}, class ExtensionsCodeview extends Gtk.Grid {
+    _init(model, path, props = {}) {
+        super._init(props);
+        this._model = model;
+        this._path = path;
+
+        this.loadFile();
+
+        this._codeview.connect('should-compile',
+            (widget, userInitiated) => this._compile(userInitiated));
+    }
+
+    loadFile() {
+        this._codeview.text = this._model.loadCodeFile(this._path);
+    }
+
+    _compile(userInitiated) {
+        this._model.updateCodeFile(this._path, this._codeview.text);
+        if (userInitiated)
+            this._model.reloadStyles('snow@endlessos.org');
+    }
+});

--- a/src/extensions/snow/controlpanel.js
+++ b/src/extensions/snow/controlpanel.js
@@ -151,6 +151,16 @@ initialFlakes = ${this._model.getVariable('_initialFlakes')};
         if (VALID_VARIABLES.every(prop => scope[prop] === null))
             return;
 
+        // Validate limits
+        if (!this._validateLimits(scope.initialFlakes, this._initialAdjustment, 6))
+            return;
+        if (!this._validateLimits(scope.max, this._maxAdjustment, 2))
+            return;
+        if (!this._validateLimits(scope.duration, this._durationAdjustment, 4))
+            return;
+        if (!this._validateLimits(scope.meltDuration, this._meltAdjustment, 5))
+            return;
+
         this._codeview.setCompileResults([]);
 
         if (userInitiated) {
@@ -161,5 +171,19 @@ initialFlakes = ${this._model.getVariable('_initialFlakes')};
             this._model.setVariable('_meltDuration', scope.meltDuration);
             this.fillAdjustements();
         }
+    }
+
+    _validateLimits(value, adjustement, line = 1) {
+        const upper = adjustement.get_upper();
+        const lower = adjustement.get_lower();
+        if (typeof value !== 'number' || value > upper || value < lower) {
+            this._codeview.setCompileResults([{
+                start: {line: line, column: 0},
+                message: `The value should be a number between ${lower} and ${upper}`,
+            }]);
+            return false;
+        }
+
+        return true;
     }
 });

--- a/src/extensions/snow/controlpanel.js
+++ b/src/extensions/snow/controlpanel.js
@@ -144,7 +144,7 @@ initialFlakes = ${this._model.getVariable('_initialFlakes')};
         } catch (e) {
             if (!(e instanceof SyntaxError || e instanceof ReferenceError))
                 throw e;
-            this._codeview.setCompileResultsFromException(e);
+            this._codeview.setCompileResultsFromException(e, true, -3);
             return;
         }
 

--- a/src/extensions/snow/controlpanel.js
+++ b/src/extensions/snow/controlpanel.js
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2020 Endless OS Foundation LLC.
+ *
+ * This file is part of hack-toolbox-app
+ * (see https://github.com/endlessm/hack-toolbox-app).
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+/* exported SnowControlPanel */
+
+const {GObject, Gtk} = imports.gi;
+const {Codeview} = imports.codeview;
+const {Section} = imports.section;
+const {SpinInput} = imports.spinInput;
+const {PopupMenu} = imports.popupMenu;
+
+GObject.type_ensure(Codeview.$gtype);
+GObject.type_ensure(Section.$gtype);
+GObject.type_ensure(SpinInput.$gtype);
+
+const VALID_VARIABLES = ['max', 'duration', 'myFlakes', 'initialFlakes', 'meltDuration'];
+
+var SnowFlake = GObject.registerClass({
+}, class SnowFlake extends Gtk.Box {
+    _init(props = {}) {
+        super._init({
+            halign: Gtk.Align.FILL,
+            orientation: Gtk.Orientation.VERTICAL,
+        });
+
+        this._label = new Gtk.Label();
+        this._label.set_markup(`<span size="xx-large">${props.flake}</span>`);
+        this.add(this._label);
+        this.show_all();
+    }
+});
+
+var SnowControlPanel = GObject.registerClass({
+    GTypeName: 'SnowControlPanel',
+    Template: 'resource:///com/hack_computer/HackToolbox/Extensions/snow/controlpanel.ui',
+    InternalChildren: [
+        'codeview',
+        'flakesButton',
+        'maxAdjustment',
+        'durationAdjustment',
+        'meltAdjustment',
+        'initialAdjustment',
+    ],
+}, class SnowControlPanel extends Gtk.Grid {
+    _init(model, props = {}) {
+        super._init(props);
+        const flakesChoices = {
+            snow: '❄',
+            santa: '🎅',
+            snowman: '⛄',
+            cat: '🐱',
+        };
+
+        this._model = model;
+
+        this._flakesGroup = new PopupMenu(
+            this._flakesButton, flakesChoices, SnowFlake, 'flake');
+        this.fillAdjustements();
+
+        this._flakesGroup.connect('notify::value', () => {
+            this._model.setFlakes(this._flakesGroup.value);
+            this.regenerateCode();
+        });
+
+        this._maxAdjustment.connect('value-changed', () => {
+            const {value} = this._maxAdjustment;
+            this._model.setVariable('_max', value);
+            this.regenerateCode();
+        });
+
+        this._durationAdjustment.connect('value-changed', () => {
+            const {value} = this._durationAdjustment;
+            this._model.setVariable('_duration', value);
+            this.regenerateCode();
+        });
+
+        this._meltAdjustment.connect('value-changed', () => {
+            const {value} = this._meltAdjustment;
+            this._model.setVariable('_meltDuration', value);
+            this.regenerateCode();
+        });
+
+        this._initialAdjustment.connect('value-changed', () => {
+            const {value} = this._initialAdjustment;
+            this._model.setVariable('_initialFlakes', value);
+            this.regenerateCode();
+        });
+
+        this._codeview.minContentHeight = 424;
+        this.regenerateCode();
+
+        this._codeview.connect('should-compile',
+            (widget, userInitiated) => this._compile(userInitiated));
+    }
+
+    fillAdjustements() {
+        this._maxAdjustment.value = this._model.getVariable('_max');
+        this._durationAdjustment.value = this._model.getVariable('_duration');
+        this._meltAdjustment.value = this._model.getVariable('_meltDuration');
+        this._initialAdjustment.value = this._model.getVariable('_initialFlakes');
+    }
+
+    regenerateCode() {
+        this._codeview.text = `
+max = ${this._model.getVariable('_max')};
+myFlakes = ${JSON.stringify(this._model.getVariable('_myFlakes'))};
+duration = ${this._model.getVariable('_duration')};
+meltDuration = ${this._model.getVariable('_meltDuration')};
+initialFlakes = ${this._model.getVariable('_initialFlakes')};
+`;
+    }
+
+    _compile(userInitiated) {
+        const code = this._codeview.text;
+
+        if (code === '')
+            return;
+
+        const scope = {};
+        VALID_VARIABLES.forEach(name => {
+            scope[name] = null;
+        });
+        try {
+            // eslint-disable-next-line no-new-func
+            const func = new Function('scope', `with(scope){\n${code}\n;}`);
+            func(scope);
+        } catch (e) {
+            if (!(e instanceof SyntaxError || e instanceof ReferenceError))
+                throw e;
+            this._codeview.setCompileResultsFromException(e);
+            return;
+        }
+
+        if (VALID_VARIABLES.every(prop => scope[prop] === null))
+            return;
+
+        this._codeview.setCompileResults([]);
+
+        if (userInitiated) {
+            this._model.setVariable('_initialFlakes', scope.initialFlakes);
+            this._model.setVariable('_max', scope.max);
+            this._model.setVariable('_myFlakes', scope.myFlakes);
+            this._model.setVariable('_duration', scope.duration);
+            this._model.setVariable('_meltDuration', scope.meltDuration);
+            this.fillAdjustements();
+        }
+    }
+});

--- a/src/extensions/snow/model.js
+++ b/src/extensions/snow/model.js
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2020 Endless OS Foundation LLC.
+ *
+ * This file is part of hack-toolbox-app
+ * (see https://github.com/endlessm/hack-toolbox-app).
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+/* exported Model */
+
+const {Gio, GLib, GObject} = imports.gi;
+
+var Model = GObject.registerClass({
+}, class Model extends GObject.Object {
+    _init() {
+        this._proxy = new Gio.DBusProxy.new_for_bus_sync(
+            Gio.BusType.SESSION,
+            0, null,
+            'org.gnome.Shell',
+            '/org/gnome/Shell',
+            'org.gnome.Shell',
+            null);
+
+        this._extensionsProxy = new Gio.DBusProxy.new_for_bus_sync(
+            Gio.BusType.SESSION,
+            0, null,
+            'org.gnome.Shell',
+            '/org/gnome/Shell',
+            'org.gnome.Shell.Extensions',
+            null);
+    }
+
+    get extensionsProxy() {
+        return this._extensionsProxy;
+    }
+
+    loadCodeFile(path) {
+        void this;
+        let code = null;
+
+        try {
+            const f = Gio.File.new_for_path(path);
+            const [, bytes] = f.load_contents(null);
+            code = imports.byteArray.toString(bytes);
+        } catch (e) {
+            log(`Failed to load code file ${path}`);
+            logError(e);
+        }
+
+        return code;
+    }
+
+    updateCodeFile(path, content) {
+        void this;
+        try {
+            GLib.file_set_contents(path, content);
+        } catch (e) {
+            log(`Failed to write code file ${path}`);
+        }
+    }
+
+    setFlakes(name) {
+        const myFlakes = {
+            snow: ['❄', '❅', '❆'],
+            santa: ['🎅', '🤶', '🎄'],
+            snowman: ['⛄'],
+            cat: ['🐱', '😻', '😸', '😽'],
+        };
+
+        this.setVariable('_myFlakes', myFlakes[name]);
+    }
+
+    getVariable(name) {
+        const code = `global.hackSnow.${name}`;
+        const variant = new GLib.Variant('(s)', [code]);
+        try {
+            const result = this._proxy.call_sync(
+                'Eval', variant, Gio.DBusCallFlags.NONE, -1, null);
+            const [, json] = result.deep_unpack();
+            return JSON.parse(json);
+        } catch (e) {
+            return 0;
+        }
+    }
+
+    setVariable(name, value) {
+        const code = `global.hackSnow.${name} = ${JSON.stringify(value)}`;
+        const variant = new GLib.Variant('(s)', [code]);
+        this._proxy.call('Eval', variant, Gio.DBusCallFlags.NONE, -1, null, () => {
+            // do nothing
+        });
+    }
+
+    reloadAllExtensions(callback) {
+        const code = 'Main.extensionManager._loadExtensions()';
+        const variant = new GLib.Variant('(s)', [code]);
+        this._proxy.call('Eval', variant, Gio.DBusCallFlags.NONE, -1, null, callback);
+    }
+
+    reloadStyles(uuid) {
+        const code = `
+let ex = Main.extensionManager.lookup('${uuid}');
+let theme = imports.gi.St.ThemeContext.get_for_stage(global.stage).get_theme();
+theme.unload_stylesheet(ex.stylesheet);
+theme.load_stylesheet(ex.stylesheet);
+`;
+        const variant = new GLib.Variant('(s)', [code]);
+        this._proxy.call('Eval', variant, Gio.DBusCallFlags.NONE, -1, null, () => {
+            // do nothing
+        });
+    }
+
+    isEnabled(uuid) {
+        const variant = new GLib.Variant('(s)', [uuid]);
+        const result = this._extensionsProxy.call_sync(
+            'GetExtensionInfo',
+            variant,
+            Gio.DBusCallFlags.NONE,
+            -1,
+            null,
+        );
+        if (!result)
+            return false;
+
+        const [info] = result.deep_unpack();
+        if (!info.state)
+            return false;
+
+        return info.state.deep_unpack() === 1;
+    }
+});

--- a/src/extensions/toolbox.js
+++ b/src/extensions/toolbox.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2020 Endless OS Foundation LLC.
+ *
+ * This file is part of hack-toolbox-app
+ * (see https://github.com/endlessm/hack-toolbox-app).
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+/* exported ExtensionsToolbox */
+
+const {GLib, GObject} = imports.gi;
+
+const {Toolbox} = imports.toolbox;
+const {SnowControlPanel} = imports.extensions.snow.controlpanel;
+const {ExtensionsCodeview} = imports.extensions.codeview;
+const {Model} = imports.extensions.snow.model;
+
+var ExtensionsToolbox = GObject.registerClass(class ExtensionsToolbox extends Toolbox {
+    _init(appId, props = {}) {
+        const home = GLib.get_home_dir();
+        const stylesPath = GLib.build_filenamev([
+            home, '.local', 'share', 'gnome-shell', 'extensions',
+            'snow@endlessos.org', 'stylesheet.css',
+        ]);
+        super._init(appId, props);
+
+        this._model = new Model();
+
+        this._signalHandler = this._model.extensionsProxy.connect(
+            'g-signal', (proxy, sender, signal, params) => {
+                if (!this._lockscreen)
+                    return;
+
+                if (signal !== 'ExtensionStateChanged')
+                    return;
+
+                const [uuid, info] = params.deep_unpack();
+                if (uuid === 'snow@endlessos.org' && info.state)
+                    this._lockscreen.locked = info.state.unpack() !== 1;
+
+                this._snowTopic.fillAdjustements();
+                this._snowTopic.regenerateCode();
+                this._stylesTopic.loadFile();
+            });
+
+        this._snowTopic = new SnowControlPanel(this._model);
+        this._stylesTopic = new ExtensionsCodeview(this._model, stylesPath);
+        this.addTopic('snow', 'Snow', 'weather-snow-symbolic', this._snowTopic);
+        this.addTopic('styles', 'Styles', 'color-select-symbolic', this._stylesTopic);
+        this.showTopic('snow');
+        this.selectTopic('snow');
+        this.show_all();
+    }
+
+    bindWindow(win) {
+        this._lockscreen = win.lockscreen;
+        if (this._model.isEnabled('snow@endlessos.org'))
+            this._lockscreen.locked = false;
+
+        win.get_style_context().add_class('Extensions');
+        win.get_style_context().add_class('Sidetrack');  // use Sidetrack shader
+    }
+
+    shutdown() {
+        this._model.extensionsProxy.disconnect(this._signalHandler);
+    }
+});

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -61,7 +61,11 @@ var Toolbox = GObject.registerClass({
 
         const appInfo = Utils.appInfoForAppId(appId);
         if (appInfo) {
-            appIcon.set_from_gicon(appInfo.get_icon(), Gtk.IconSize.DIALOG);
+            const icon = appInfo.get_icon();
+            if (icon)
+                appIcon.set_from_gicon(icon, Gtk.IconSize.DIALOG);
+            else
+                appIcon.set_from_icon_name('user-available', Gtk.IconSize.DIALOG);
             appNameLabel.label = appInfo.get_name();
         } else {
             // Application not installed, this is not expected during normal

--- a/src/utils.js
+++ b/src/utils.js
@@ -112,7 +112,11 @@ function appInfoForAppId(id) {
             const iconsDir = 'icons/hicolor/128x128/apps';
             const iconName = desktopFile.get_string('Desktop Entry', 'Icon') || id;
             const iconPath = GLib.build_filenamev([datadir, iconsDir, `${iconName}.png`]);
-            return Gio.FileIcon.new(Gio.File.new_for_path(iconPath));
+            const file = Gio.File.new_for_path(iconPath);
+            if (!file.query_exists(null))
+                return null;
+
+            return Gio.FileIcon.new(file);
         };
 
         return appInfo;


### PR DESCRIPTION
This patch adds a new toolbox for the `org.gnome.Extensions` app that provides some configuration and hacking on this gnome-shell extension: https://github.com/danigm/snow-extension/

The toolbox is locked if the extension is not installed or enabled and provides some controls to update the behavior in runtime.

https://phabricator.endlessm.com/T31164